### PR TITLE
Introduce libzlmp ("zig lua message pack") and implement the serialization side.

### DIFF
--- a/.justfile
+++ b/.justfile
@@ -4,12 +4,19 @@ abs := "readlink -f $1"
 regression_tester := shell(abs, "./src/tests/regression.py")
 regression_suite := shell(abs, "./src/tests/test-suite/")
 
+sample_spell := shell(abs, "./src/tests/test-suite/decrement-counter/spell.lua")
+sample_event := shell(abs, "./src/tests/test-suite/decrement-counter/seed.lua")
+
 sanctum := shell(abs, "./zig-out/bin/sanctum")
 
 test: build (_test regression_tester sanctum regression_suite "--test")
 freeze: build (_test regression_tester sanctum regression_suite "--freeze")
 _test script executable suite flags:
     @python3 {{script}} {{executable}} {{suite}} {{flags}}
+
+run: build (_run sanctum sample_spell sample_event)
+_run executable spell event:
+    @{{executable}} cast {{sample_spell}} --seed {{sample_event}}
 
 build:
     zig build

--- a/build.zig
+++ b/build.zig
@@ -28,6 +28,12 @@ pub fn build(b: *std.Build) void {
         .optimize = optimize,
     });
 
+    const libzlmp = b.createModule(.{
+        .root_source_file = b.path("src/zlmp.zig"),
+        .target = target,
+        .optimize = optimize,
+    });
+
     // We will also create a module for our other entry point, 'main.zig'.
     const exe_mod = b.createModule(.{
         // `root_source_file` is the Zig "entry point" of the module. If a module
@@ -43,6 +49,7 @@ pub fn build(b: *std.Build) void {
     // This is what allows Zig source code to use `@import("foo")` where 'foo' is not a
     // file path. In this case, we set up `exe_mod` to import `lib_mod`.
     exe_mod.addImport("libsanctum", libsanctum);
+    exe_mod.addImport("libzlmp", libzlmp);
 
     // Now, we will create a static library based on the module we created above.
     // This creates a `std.Build.Step.Compile`, which is the build step responsible
@@ -52,10 +59,16 @@ pub fn build(b: *std.Build) void {
         .root_module = libsanctum,
     });
 
+    const lib_static_zlmp = b.addStaticLibrary(.{
+        .name = "zlmp",
+        .root_module = libzlmp,
+    });
+
     // This declares intent for the library to be installed into the standard
     // location when the user invokes the "install" step (the default step when
     // running `zig build`).
     b.installArtifact(lib);
+    b.installArtifact(lib_static_zlmp);
 
     // This creates another `std.Build.Step.Compile`, but this one builds an executable
     // rather than a static library.
@@ -71,6 +84,7 @@ pub fn build(b: *std.Build) void {
     });
     const ziglua = ziglua_dep.module("ziglua");
     exe.root_module.addImport("ziglua", ziglua);
+    lib_static_zlmp.root_module.addImport("ziglua", ziglua);
 
     // This declares intent for the executable to be installed into the
     // standard location when the user invokes the "install" step (the default
@@ -105,8 +119,12 @@ pub fn build(b: *std.Build) void {
     const lib_unit_tests = b.addTest(.{
         .root_module = libsanctum,
     });
+    const libzlmp_unit_tests = b.addTest(.{
+        .root_module = libzlmp,
+    });
 
     const run_lib_unit_tests = b.addRunArtifact(lib_unit_tests);
+    const run_libzlmp_unit_tests = b.addRunArtifact(libzlmp_unit_tests);
 
     const exe_unit_tests = b.addTest(.{
         .root_module = exe_mod,
@@ -118,6 +136,7 @@ pub fn build(b: *std.Build) void {
     // the `zig build --help` menu, providing a way for the user to request
     // running the unit tests.
     const test_step = b.step("test", "Run unit tests");
+    test_step.dependOn(&run_libzlmp_unit_tests.step);
     test_step.dependOn(&run_lib_unit_tests.step);
     test_step.dependOn(&run_exe_unit_tests.step);
 }

--- a/src/main.zig
+++ b/src/main.zig
@@ -1,6 +1,7 @@
 const std = @import("std");
 const ziglua = @import("ziglua");
 const sanctum = @import("libsanctum");
+const zlmp = @import("libzlmp");
 
 const Lua = ziglua.Lua;
 const LuaType = ziglua.LuaType;
@@ -124,131 +125,16 @@ fn runCommand(alloc: std.mem.Allocator, command: RunCommandArgs) !void {
     try prepareSpellCall(lua, "cast", 1);
 
     // Temporary: Do a round trip serialization.
-    const event: MessagePackBuffer = try toMessagePack(lua, alloc);
+    const event: zlmp.MessagePackBuffer = try zlmp.toMessagePack(lua, alloc);
     defer alloc.free(event.data);
     lua.pop(1);
-    try pushMessagePack(lua, event);
+    try zlmp.pushMessagePack(lua, event);
 
     var i: usize = 0;
     while (!shouldStop(lua, i)) : (i += 1) {
         try checkedCall(lua, command);
         try prepareSpellCall(lua, "cast", 1);
     }
-}
-
-const MessagePackBuffer = struct {
-    data: []const u8,
-};
-
-fn toMessagePack(lua: *Lua, alloc: std.mem.Allocator) !MessagePackBuffer {
-    try guardTypeAt(lua, LuaType.table, -1);
-
-    const size: usize = try messagePackSizeOfTable(lua, -1);
-    const buffer: []u8 = try alloc.alloc(u8, size);
-    _ = try messagePack(lua, buffer, -1);
-    return .{ .data = buffer };
-}
-
-fn messagePackSizeOfTable(lua: *Lua, table_offset: i32) !usize {
-    try guardTypeAt(lua, LuaType.table, table_offset);
-
-    // Message pack supports maps with varying sizes and varying overhead. For now, to keep it simple we will support
-    // the largest map capacity with the largest overhead instead of trying to calculate the optimal value (which depends
-    // on the number of key value pairs in the map).
-    // Refer to https://github.com/msgpack/msgpack/blob/master/spec.md#map-format-family
-    const messagePackMapOverheadBytes = 5;
-
-    var sz: usize = 0;
-    sz += messagePackMapOverheadBytes;
-
-    // Refer to https://www.lua.org/manual/5.4/manual.html#lua_next for table iteration pattern.
-    lua.pushNil();
-    while (lua.next(table_offset - 1)) {
-        sz += if (lua.typeOf(-1) == LuaType.table) try messagePackSizeOfTable(lua, -1) else try messagePackSizeOf(lua, -1);
-        lua.pop(1);
-
-        sz += if (lua.typeOf(-1) == LuaType.table) try messagePackSizeOfTable(lua, -1) else try messagePackSizeOf(lua, -1);
-    }
-
-    std.debug.print("Table will fit in {d} bytes using MessagePack.\n", .{sz});
-    return sz;
-}
-
-fn messagePackSizeOf(lua: *Lua, offset: i32) !usize {
-    return switch (lua.typeOf(offset)) {
-        .nil => 1,
-        .boolean => 1,
-        .number => if (lua.isInteger(offset)) @sizeOf(LuaInteger) else @sizeOf(LuaNumber),
-        .string => lua.rawLen(offset),
-
-        // The caller must enumerate the contents of the table and ask for the the size of each of the objects within the table.
-        // It is not valid to ask for the size of the table itself.
-        .table => error.SizeOfTableNotSupported,
-
-        // Events are data-only tables, we will ignore all non-data types.
-        .none, .function, .userdata, .light_userdata, .thread => 0,
-    };
-}
-
-fn guardTypeAt(lua: *Lua, expected_type: LuaType, offset: i32) !void {
-    const actual_type = lua.typeOf(offset);
-    if (expected_type != actual_type) {
-        std.debug.print("[Guard] Expected to find a '{s}' on the stack at ({d}) but found a '{s}' instead.\n", .{ @tagName(expected_type), offset, @tagName(actual_type) });
-    }
-}
-
-fn messagePack(lua: *Lua, buffer: []u8, table_offset: i32) !usize {
-    try guardTypeAt(lua, LuaType.table, table_offset);
-
-    var i: usize = 0;
-    var number_of_key_value_pairs: u32 = 0;
-
-    // map32 byte
-    buffer[i] = 0xdf;
-    i += 1;
-
-    // Skip the 32-bit count of key value pairs.
-    i += 4;
-
-    lua.pushNil();
-    while (lua.next(table_offset - 1)) {
-        number_of_key_value_pairs += 1;
-
-        // Message pack expects keys to be followed by values, so reorder them on the stack before writing to the buffer.
-        lua.insert(-2);
-        i += if (lua.typeOf(-1) == LuaType.table) try messagePack(lua, buffer[i..], -1) else try packValue(lua, buffer[i..], -1);
-
-        // Need to reorder again to make sure the key stays on the stack for next iteration.
-        lua.insert(-2);
-        lua.pop(1);
-    }
-
-    // TODO: Write the number of key value pairs to buffer[start + 1 .. start + 5]
-    return i;
-}
-
-fn packValue(lua: *Lua, buffer: []u8, offset: i32) !usize {
-    _ = buffer;
-    return switch (lua.typeOf(offset)) {
-        .nil => blk: {
-            break :blk 1;
-        },
-        .boolean => 1,
-        .number => if (lua.isInteger(offset)) @sizeOf(LuaInteger) else @sizeOf(LuaNumber),
-        .string => lua.rawLen(offset),
-
-        // The caller must enumerate the contents of the table and ask for the the size of each of the objects within the table.
-        // It is not valid to ask for the size of the table itself.
-        .table => error.SizeOfTableNotSupported,
-
-        // Events are data-only tables, we will ignore all non-data types.
-        .none, .function, .userdata, .light_userdata, .thread => 0,
-    };
-}
-
-fn pushMessagePack(lua: *Lua, event: MessagePackBuffer) !void {
-    _ = lua;
-    _ = event;
 }
 
 fn validateCallable(lua: *Lua, function_name: [:0]const u8, lua_source: [:0]const u8) !void {

--- a/src/main.zig
+++ b/src/main.zig
@@ -4,6 +4,8 @@ const sanctum = @import("libsanctum");
 
 const Lua = ziglua.Lua;
 const LuaType = ziglua.LuaType;
+const LuaInteger = ziglua.Integer;
+const LuaNumber = ziglua.Number;
 
 const MAX_SPELL_SIZE_BYTES: usize = 1024 * 512;
 
@@ -121,11 +123,132 @@ fn runCommand(alloc: std.mem.Allocator, command: RunCommandArgs) !void {
     try checkedDoString(lua, command.event_seed_lua);
     try prepareSpellCall(lua, "cast", 1);
 
+    // Temporary: Do a round trip serialization.
+    const event: MessagePackBuffer = try toMessagePack(lua, alloc);
+    defer alloc.free(event.data);
+    lua.pop(1);
+    try pushMessagePack(lua, event);
+
     var i: usize = 0;
     while (!shouldStop(lua, i)) : (i += 1) {
         try checkedCall(lua, command);
         try prepareSpellCall(lua, "cast", 1);
     }
+}
+
+const MessagePackBuffer = struct {
+    data: []const u8,
+};
+
+fn toMessagePack(lua: *Lua, alloc: std.mem.Allocator) !MessagePackBuffer {
+    try guardTypeAt(lua, LuaType.table, -1);
+
+    const size: usize = try messagePackSizeOfTable(lua, -1);
+    const buffer: []u8 = try alloc.alloc(u8, size);
+    _ = try messagePack(lua, buffer, -1);
+    return .{ .data = buffer };
+}
+
+fn messagePackSizeOfTable(lua: *Lua, table_offset: i32) !usize {
+    try guardTypeAt(lua, LuaType.table, table_offset);
+
+    // Message pack supports maps with varying sizes and varying overhead. For now, to keep it simple we will support
+    // the largest map capacity with the largest overhead instead of trying to calculate the optimal value (which depends
+    // on the number of key value pairs in the map).
+    // Refer to https://github.com/msgpack/msgpack/blob/master/spec.md#map-format-family
+    const messagePackMapOverheadBytes = 5;
+
+    var sz: usize = 0;
+    sz += messagePackMapOverheadBytes;
+
+    // Refer to https://www.lua.org/manual/5.4/manual.html#lua_next for table iteration pattern.
+    lua.pushNil();
+    while (lua.next(table_offset - 1)) {
+        sz += if (lua.typeOf(-1) == LuaType.table) try messagePackSizeOfTable(lua, -1) else try messagePackSizeOf(lua, -1);
+        lua.pop(1);
+
+        sz += if (lua.typeOf(-1) == LuaType.table) try messagePackSizeOfTable(lua, -1) else try messagePackSizeOf(lua, -1);
+    }
+
+    std.debug.print("Table will fit in {d} bytes using MessagePack.\n", .{sz});
+    return sz;
+}
+
+fn messagePackSizeOf(lua: *Lua, offset: i32) !usize {
+    return switch (lua.typeOf(offset)) {
+        .nil => 1,
+        .boolean => 1,
+        .number => if (lua.isInteger(offset)) @sizeOf(LuaInteger) else @sizeOf(LuaNumber),
+        .string => lua.rawLen(offset),
+
+        // The caller must enumerate the contents of the table and ask for the the size of each of the objects within the table.
+        // It is not valid to ask for the size of the table itself.
+        .table => error.SizeOfTableNotSupported,
+
+        // Events are data-only tables, we will ignore all non-data types.
+        .none, .function, .userdata, .light_userdata, .thread => 0,
+    };
+}
+
+fn guardTypeAt(lua: *Lua, expected_type: LuaType, offset: i32) !void {
+    const actual_type = lua.typeOf(offset);
+    if (expected_type != actual_type) {
+        std.debug.print("[Guard] Expected to find a '{s}' on the stack at ({d}) but found a '{s}' instead.\n", .{ @tagName(expected_type), offset, @tagName(actual_type) });
+    }
+}
+
+fn messagePack(lua: *Lua, buffer: []u8, table_offset: i32) !usize {
+    try guardTypeAt(lua, LuaType.table, table_offset);
+
+    var i: usize = 0;
+    var number_of_key_value_pairs: u32 = 0;
+
+    // map32 byte
+    buffer[i] = 0xdf;
+    i += 1;
+
+    // Skip the 32-bit count of key value pairs.
+    i += 4;
+
+    lua.pushNil();
+    while (lua.next(table_offset - 1)) {
+        number_of_key_value_pairs += 1;
+
+        // Message pack expects keys to be followed by values, so reorder them on the stack before writing to the buffer.
+        lua.insert(-2);
+        i += if (lua.typeOf(-1) == LuaType.table) try messagePack(lua, buffer[i..], -1) else try packValue(lua, buffer[i..], -1);
+
+        // Need to reorder again to make sure the key stays on the stack for next iteration.
+        lua.insert(-2);
+        lua.pop(1);
+    }
+
+    // TODO: Write the number of key value pairs to buffer[start + 1 .. start + 5]
+    return i;
+}
+
+fn packValue(lua: *Lua, buffer: []u8, offset: i32) !usize {
+    _ = buffer;
+    return switch (lua.typeOf(offset)) {
+        .nil => blk: {
+            break :blk 1;
+        },
+        .boolean => 1,
+        .number => if (lua.isInteger(offset)) @sizeOf(LuaInteger) else @sizeOf(LuaNumber),
+        .string => lua.rawLen(offset),
+
+        // The caller must enumerate the contents of the table and ask for the the size of each of the objects within the table.
+        // It is not valid to ask for the size of the table itself.
+        .table => error.SizeOfTableNotSupported,
+
+        // Events are data-only tables, we will ignore all non-data types.
+        .none, .function, .userdata, .light_userdata, .thread => 0,
+    };
+}
+
+fn pushMessagePack(lua: *Lua, event: MessagePackBuffer) !void {
+    _ = lua;
+    _ = event;
 }
 
 fn validateCallable(lua: *Lua, function_name: [:0]const u8, lua_source: [:0]const u8) !void {

--- a/src/main.zig
+++ b/src/main.zig
@@ -128,8 +128,12 @@ fn runCommand(alloc: std.mem.Allocator, command: RunCommandArgs) !void {
     try guardTypeAt(lua, LuaType.table, -1);
     const event: zlmp.MessagePackBuffer = try zlmp.toMessagePack(lua, -1, alloc);
     defer alloc.free(event.message);
-    lua.pop(1);
-    try zlmp.pushMessagePack(lua, event);
+
+    // var buf: [8192]u8 = undefined;
+    // const b64 = std.base64.standard.Encoder.encode(&buf, event.message);
+    // std.debug.print("https://msgpack.dbrgn.ch/#base64={s}\n", .{b64});
+    // lua.pop(1);
+    // try zlmp.pushMessagePack(lua, event);
 
     var i: usize = 0;
     while (!shouldStop(lua, i)) : (i += 1) {

--- a/src/tests/test-suite/decrement-counter/seed.lua
+++ b/src/tests/test-suite/decrement-counter/seed.lua
@@ -1,1 +1,2 @@
-return { counter = 10 }
+-- return { counter = 10 }
+return { 1, 2, 3, counter = 10, foo = function() end, hello_world = "Hello, very beautiful world!", f = nil, is_abc = true, table = { ["xyz"] = true } }

--- a/src/zlmp.zig
+++ b/src/zlmp.zig
@@ -1,4 +1,5 @@
 const std = @import("std");
+const ArrayList = std.ArrayList;
 
 const ziglua = @import("ziglua");
 
@@ -7,8 +8,66 @@ const LuaType = ziglua.LuaType;
 const LuaInteger = ziglua.Integer;
 const LuaNumber = ziglua.Number;
 
+const Protocol = struct {
+    const Tag = enum(u8) {
+        // Positive fixint range (0 to 127)
+        PositiveFixintMin = 0x00,
+        PositiveFixintMax = 0x7f,
+
+        // Fixmap range (0 to 15 elements)
+        FixmapMin = 0x80,
+        FixmapMax = 0x8f,
+
+        // Fixarray range (0 to 15 elements)
+        FixarrayMin = 0x90,
+        FixarrayMax = 0x9f,
+
+        // Fixstr range (0 to 31 bytes)
+        FixstrMin = 0xa0,
+        FixstrMax = 0xbf,
+
+        // Specific values
+        Nil = 0xc0,
+        NeverUsed = 0xc1,
+        False = 0xc2,
+        True = 0xc3,
+        Bin8 = 0xc4,
+        Bin16 = 0xc5,
+        Bin32 = 0xc6,
+        Ext8 = 0xc7,
+        Ext16 = 0xc8,
+        Ext32 = 0xc9,
+        Float32 = 0xca,
+        Float64 = 0xcb,
+        Uint8 = 0xcc,
+        Uint16 = 0xcd,
+        Uint32 = 0xce,
+        Uint64 = 0xcf,
+        Int8 = 0xd0,
+        Int16 = 0xd1,
+        Int32 = 0xd2,
+        Int64 = 0xd3,
+        Fixext1 = 0xd4,
+        Fixext2 = 0xd5,
+        Fixext4 = 0xd6,
+        Fixext8 = 0xd7,
+        Fixext16 = 0xd8,
+        Str8 = 0xd9,
+        Str16 = 0xda,
+        Str32 = 0xdb,
+        Array16 = 0xdc,
+        Array32 = 0xdd,
+        Map16 = 0xde,
+        Map32 = 0xdf,
+
+        // Negative fixint range (-32 to -1)
+        NegativeFixintMin = 0xe0,
+        NegativeFixintMax = 0xff,
+    };
+};
+
 pub const MessagePackBuffer = struct {
-    data: []const u8,
+    message: []const u8,
 };
 
 pub fn pushMessagePack(lua: *Lua, event: MessagePackBuffer) !void {
@@ -16,108 +75,127 @@ pub fn pushMessagePack(lua: *Lua, event: MessagePackBuffer) !void {
     _ = event;
 }
 
-pub fn toMessagePack(lua: *Lua, alloc: std.mem.Allocator) !MessagePackBuffer {
-    try guardTypeAt(lua, LuaType.table, -1);
+/// Controls how zlmp allocates memory when serializing lua values.
+pub const AllocationStrategy = enum(u8) {
+    /// zlmp will pre-traverse the value to calculate the required space before
+    /// beginning serialization. Optimal when objects to be serialized are known
+    /// ahead of time to be relatively small.
+    exact,
+    /// zlmp will allocate an average sized buffer and grow the buffer with calls
+    /// to realloc as necessary. Optimal when objects to be serialied are known
+    /// ahead of time to be relatively large.
+    realloc,
+};
+pub const ToMessagePackOptions = struct {
+    /// When using the 'realloc' allocation strategy, the initial_capacity
+    /// determines the size of the first buffer allocated during serialization.
+    initial_capacity: u16 = 1024,
 
-    const size: usize = try messagePackSizeOfTable(lua, -1);
-    const buffer: []u8 = try alloc.alloc(u8, size);
-    _ = try messagePack(lua, buffer, -1);
-    return .{ .data = buffer };
+    /// Controls how zlmp allocates memory when serializing lua values.
+    allocation_strategy: AllocationStrategy = .exact,
+};
+
+pub fn toMessagePack(
+    lua: *Lua,
+    index: i32,
+    alloc: std.mem.Allocator,
+) !MessagePackBuffer {
+    return toMessagePackOptions(lua, index, alloc, .{});
 }
 
-fn messagePackSizeOfTable(lua: *Lua, table_offset: i32) !usize {
-    try guardTypeAt(lua, LuaType.table, table_offset);
+/// Serializes the value on the stack at the specified index to a MessagePack message.
+/// For now, only lua tables may be serialized. An error will be returned if the stack
+/// does not contain a table at the specified index.
+///
+/// * Pops: `0`
+/// * Pushes: `0`
+/// * Errors: error.GuardFail - when the value at the specified index is not a table.
+pub fn toMessagePackOptions(
+    lua: *Lua,
+    index: i32,
+    alloc: std.mem.Allocator,
+    options: ToMessagePackOptions,
+) !MessagePackBuffer {
+    var al = try switch (options.allocation_strategy) {
+        .exact => blk: {
+            const size: usize = try sizeOf(lua, index);
+            break :blk ArrayList(u8).initCapacity(alloc, size);
+        },
+        .realloc => ArrayList(u8).initCapacity(alloc, options.initial_capacity),
+    };
+    defer al.deinit();
 
+    _ = try packInto(lua, &al, index);
+
+    // TODO: toOwnedSlice reallocates again. It might make more sense to either
+    // embed the array list inside the returned struct, providing a method for getting
+    // the data slice, and doing cleanup on deinit; or to pull the slice from the array
+    // list without using `toOwnedSlice`. I don't know if I can just return `allocatedSlice`
+    // and have the caller correctly deallocate it?
+    return .{ .message = try al.toOwnedSlice() };
+}
+
+fn packInto(lua: *Lua, al: *ArrayList(u8), index: i32) !void {
+    var writer = al.writer();
+    switch (lua.typeOf(index)) {
+        .nil => {
+            try writer.writeByte(0xc0);
+        },
+        .boolean => {},
+        .number => if (lua.isInteger(index)) {} else {},
+        .string => {},
+        .table => {
+            // Refer to https://www.lua.org/manual/5.4/manual.html#lua_next for table iteration pattern.
+            lua.pushNil();
+            while (lua.next(index - 1)) {
+                lua.pop(1);
+            }
+        },
+
+        // All non-data types will be ignored by design. These types cannot be serialized to the
+        // message pack format and will be lost during a round trip through serialization.
+        .none, .function, .thread => {},
+
+        // We may end up implementing various functionalities via these types, but they will always
+        // be platform-provided and not meaningful to any user-controlled data object.
+        .userdata, .light_userdata => {},
+    }
+}
+
+fn sizeOf(lua: *Lua, index: i32) !usize {
     // Message pack supports maps with varying sizes and varying overhead. For now, to keep it simple we will support
     // the largest map capacity with the largest overhead instead of trying to calculate the optimal value (which depends
     // on the number of key value pairs in the map).
     // Refer to https://github.com/msgpack/msgpack/blob/master/spec.md#map-format-family
     const messagePackMapOverheadBytes = 5;
 
-    var sz: usize = 0;
-    sz += messagePackMapOverheadBytes;
-
-    // Refer to https://www.lua.org/manual/5.4/manual.html#lua_next for table iteration pattern.
-    lua.pushNil();
-    while (lua.next(table_offset - 1)) {
-        sz += if (lua.typeOf(-1) == LuaType.table) try messagePackSizeOfTable(lua, -1) else try messagePackSizeOf(lua, -1);
-        lua.pop(1);
-
-        sz += if (lua.typeOf(-1) == LuaType.table) try messagePackSizeOfTable(lua, -1) else try messagePackSizeOf(lua, -1);
-    }
-
-    std.debug.print("Table will fit in {d} bytes using MessagePack.\n", .{sz});
-    return sz;
-}
-
-fn messagePackSizeOf(lua: *Lua, offset: i32) !usize {
-    return switch (lua.typeOf(offset)) {
+    return switch (lua.typeOf(index)) {
         .nil => 1,
         .boolean => 1,
-        .number => if (lua.isInteger(offset)) @sizeOf(LuaInteger) else @sizeOf(LuaNumber),
-        .string => lua.rawLen(offset),
+        .number => if (lua.isInteger(index)) @sizeOf(LuaInteger) else @sizeOf(LuaNumber),
+        .string => lua.rawLen(index),
+        .table => blk: {
+            var sz: usize = 0;
+            sz += messagePackMapOverheadBytes;
 
-        // The caller must enumerate the contents of the table and ask for the the size of each of the objects within the table.
-        // It is not valid to ask for the size of the table itself.
-        .table => error.SizeOfTableNotSupported,
+            // Refer to https://www.lua.org/manual/5.4/manual.html#lua_next for table iteration pattern.
+            lua.pushNil();
+            while (lua.next(index - 1)) {
+                sz += try sizeOf(lua, -1);
+                lua.pop(1);
 
-        // Events are data-only tables, we will ignore all non-data types.
-        .none, .function, .userdata, .light_userdata, .thread => 0,
-    };
-}
+                sz += try sizeOf(lua, -1);
+            }
 
-fn guardTypeAt(lua: *Lua, expected_type: LuaType, offset: i32) !void {
-    const actual_type = lua.typeOf(offset);
-    if (expected_type != actual_type) {
-        std.debug.print("[Guard] Expected to find a '{s}' on the stack at ({d}) but found a '{s}' instead.\n", .{ @tagName(expected_type), offset, @tagName(actual_type) });
-    }
-}
-
-fn messagePack(lua: *Lua, buffer: []u8, table_offset: i32) !usize {
-    try guardTypeAt(lua, LuaType.table, table_offset);
-
-    var i: usize = 0;
-    var number_of_key_value_pairs: u32 = 0;
-
-    // map32 byte
-    buffer[i] = 0xdf;
-    i += 1;
-
-    // Skip the 32-bit count of key value pairs.
-    i += 4;
-
-    lua.pushNil();
-    while (lua.next(table_offset - 1)) {
-        number_of_key_value_pairs += 1;
-
-        // Message pack expects keys to be followed by values, so reorder them on the stack before writing to the buffer.
-        lua.insert(-2);
-        i += if (lua.typeOf(-1) == LuaType.table) try messagePack(lua, buffer[i..], -1) else try packValue(lua, buffer[i..], -1);
-
-        // Need to reorder again to make sure the key stays on the stack for next iteration.
-        lua.insert(-2);
-        lua.pop(1);
-    }
-
-    // TODO: Write the number of key value pairs to buffer[start + 1 .. start + 5]
-    return i;
-}
-
-fn packValue(lua: *Lua, buffer: []u8, offset: i32) !usize {
-    _ = buffer;
-    return switch (lua.typeOf(offset)) {
-        .nil => blk: {
-            break :blk 1;
+            break :blk sz;
         },
-        .boolean => 1,
-        .number => if (lua.isInteger(offset)) @sizeOf(LuaInteger) else @sizeOf(LuaNumber),
-        .string => lua.rawLen(offset),
 
-        // The caller must enumerate the contents of the table and ask for the the size of each of the objects within the table.
-        // It is not valid to ask for the size of the table itself.
-        .table => error.SizeOfTableNotSupported,
+        // All non-data types will be ignored by design. These types cannot be serialized to the
+        // message pack format and will be lost during a round trip through serialization.
+        .none, .function, .thread => 0,
 
-        // Events are data-only tables, we will ignore all non-data types.
-        .none, .function, .userdata, .light_userdata, .thread => 0,
+        // We may end up implementing various functionalities via these types, but they will always
+        // be platform-provided and not meaningful to any user-controlled data object.
+        .userdata, .light_userdata => 0,
     };
 }

--- a/src/zlmp.zig
+++ b/src/zlmp.zig
@@ -1,0 +1,123 @@
+const std = @import("std");
+
+const ziglua = @import("ziglua");
+
+const Lua = ziglua.Lua;
+const LuaType = ziglua.LuaType;
+const LuaInteger = ziglua.Integer;
+const LuaNumber = ziglua.Number;
+
+pub const MessagePackBuffer = struct {
+    data: []const u8,
+};
+
+pub fn pushMessagePack(lua: *Lua, event: MessagePackBuffer) !void {
+    _ = lua;
+    _ = event;
+}
+
+pub fn toMessagePack(lua: *Lua, alloc: std.mem.Allocator) !MessagePackBuffer {
+    try guardTypeAt(lua, LuaType.table, -1);
+
+    const size: usize = try messagePackSizeOfTable(lua, -1);
+    const buffer: []u8 = try alloc.alloc(u8, size);
+    _ = try messagePack(lua, buffer, -1);
+    return .{ .data = buffer };
+}
+
+fn messagePackSizeOfTable(lua: *Lua, table_offset: i32) !usize {
+    try guardTypeAt(lua, LuaType.table, table_offset);
+
+    // Message pack supports maps with varying sizes and varying overhead. For now, to keep it simple we will support
+    // the largest map capacity with the largest overhead instead of trying to calculate the optimal value (which depends
+    // on the number of key value pairs in the map).
+    // Refer to https://github.com/msgpack/msgpack/blob/master/spec.md#map-format-family
+    const messagePackMapOverheadBytes = 5;
+
+    var sz: usize = 0;
+    sz += messagePackMapOverheadBytes;
+
+    // Refer to https://www.lua.org/manual/5.4/manual.html#lua_next for table iteration pattern.
+    lua.pushNil();
+    while (lua.next(table_offset - 1)) {
+        sz += if (lua.typeOf(-1) == LuaType.table) try messagePackSizeOfTable(lua, -1) else try messagePackSizeOf(lua, -1);
+        lua.pop(1);
+
+        sz += if (lua.typeOf(-1) == LuaType.table) try messagePackSizeOfTable(lua, -1) else try messagePackSizeOf(lua, -1);
+    }
+
+    std.debug.print("Table will fit in {d} bytes using MessagePack.\n", .{sz});
+    return sz;
+}
+
+fn messagePackSizeOf(lua: *Lua, offset: i32) !usize {
+    return switch (lua.typeOf(offset)) {
+        .nil => 1,
+        .boolean => 1,
+        .number => if (lua.isInteger(offset)) @sizeOf(LuaInteger) else @sizeOf(LuaNumber),
+        .string => lua.rawLen(offset),
+
+        // The caller must enumerate the contents of the table and ask for the the size of each of the objects within the table.
+        // It is not valid to ask for the size of the table itself.
+        .table => error.SizeOfTableNotSupported,
+
+        // Events are data-only tables, we will ignore all non-data types.
+        .none, .function, .userdata, .light_userdata, .thread => 0,
+    };
+}
+
+fn guardTypeAt(lua: *Lua, expected_type: LuaType, offset: i32) !void {
+    const actual_type = lua.typeOf(offset);
+    if (expected_type != actual_type) {
+        std.debug.print("[Guard] Expected to find a '{s}' on the stack at ({d}) but found a '{s}' instead.\n", .{ @tagName(expected_type), offset, @tagName(actual_type) });
+    }
+}
+
+fn messagePack(lua: *Lua, buffer: []u8, table_offset: i32) !usize {
+    try guardTypeAt(lua, LuaType.table, table_offset);
+
+    var i: usize = 0;
+    var number_of_key_value_pairs: u32 = 0;
+
+    // map32 byte
+    buffer[i] = 0xdf;
+    i += 1;
+
+    // Skip the 32-bit count of key value pairs.
+    i += 4;
+
+    lua.pushNil();
+    while (lua.next(table_offset - 1)) {
+        number_of_key_value_pairs += 1;
+
+        // Message pack expects keys to be followed by values, so reorder them on the stack before writing to the buffer.
+        lua.insert(-2);
+        i += if (lua.typeOf(-1) == LuaType.table) try messagePack(lua, buffer[i..], -1) else try packValue(lua, buffer[i..], -1);
+
+        // Need to reorder again to make sure the key stays on the stack for next iteration.
+        lua.insert(-2);
+        lua.pop(1);
+    }
+
+    // TODO: Write the number of key value pairs to buffer[start + 1 .. start + 5]
+    return i;
+}
+
+fn packValue(lua: *Lua, buffer: []u8, offset: i32) !usize {
+    _ = buffer;
+    return switch (lua.typeOf(offset)) {
+        .nil => blk: {
+            break :blk 1;
+        },
+        .boolean => 1,
+        .number => if (lua.isInteger(offset)) @sizeOf(LuaInteger) else @sizeOf(LuaNumber),
+        .string => lua.rawLen(offset),
+
+        // The caller must enumerate the contents of the table and ask for the the size of each of the objects within the table.
+        // It is not valid to ask for the size of the table itself.
+        .table => error.SizeOfTableNotSupported,
+
+        // Events are data-only tables, we will ignore all non-data types.
+        .none, .function, .userdata, .light_userdata, .thread => 0,
+    };
+}

--- a/src/zlmp.zig
+++ b/src/zlmp.zig
@@ -190,7 +190,7 @@ fn packMapInto(al: *ArrayList(u8), writer: *ArrayList(u8).Writer, lua: *Lua, ind
     // and reallocate the buffer while we write the key value pairs into it. Instead,
     // the offset of this u32 in the buffer can be saved, and we can update the memory
     // with that stable offset later.
-    const placeholder_location = al.capacity;
+    const placeholder_location = al.items.len;
 
     // We are going to "come back" to setting `N` in the serialized output after
     // writing the `N*2` objects. At that point we will know the value of `N`.


### PR DESCRIPTION
* Add `libzlmp` library to project. The "Zig Lua Message Pack" library will be responsible for [de]serializing Lua data to binary for storage and network transmission.
* Add back the `just run` target to cast a particular spell in the sanctum executable. This is useful for smell-checking changes even when the regression tests are known to be broken.
* Change the `decrement-counter` spell to use a complicated seed event with a wide variety of data types to validate serialization.